### PR TITLE
[Security] Ensure instantiated objects are not blacklisted in plugin methods

### DIFF
--- a/src/CompiledAssembly.cs
+++ b/src/CompiledAssembly.cs
@@ -169,13 +169,8 @@ namespace Oxide.Plugins
                                 Instruction first = instructions.First();
 
                                 int i = 0;
-                                while (i < instructions.Count)
+                                while (i < instructions.Count && !changedMethod)
                                 {
-                                    if (changedMethod)
-                                    {
-                                        break;
-                                    }
-
                                     Instruction instruction = instructions[i];
                                     if (instruction.OpCode == OpCodes.Ldtoken)
                                     {
@@ -189,7 +184,7 @@ namespace Oxide.Plugins
                                             changedMethod = true;
                                         }
                                     }
-                                    else if (instruction.OpCode == OpCodes.Call || instruction.OpCode == OpCodes.Calli || instruction.OpCode == OpCodes.Callvirt || instruction.OpCode == OpCodes.Ldftn)
+                                    else if (instruction.OpCode == OpCodes.Call || instruction.OpCode == OpCodes.Calli || instruction.OpCode == OpCodes.Callvirt || instruction.OpCode == OpCodes.Ldftn || instruction.OpCode == OpCodes.Newobj)
                                     {
                                         MethodReference methodCall = instruction.Operand as MethodReference;
                                         string fullNamespace = methodCall?.DeclaringType.FullName;


### PR DESCRIPTION
This pull request ensures that none of the instantiated objects in plugin methods are blacklisted, otherwise an exception will be thrown.

# Details
## Plugin code
```cs
using (var ms = new MemoryStream())
{
    new FileStream("/etc/hosts", FileMode.Open, FileAccess.Read).CopyTo(ms);
    Puts(Encoding.Default.GetString(ms.ToArray()));
}
```
## Current output
```
127.0.0.1 localhost
```
## Expected output
After applying this patch it will throw an error instead:
```cs
Failed to call hook 'OnServerInitialized' on plugin 'FSTest v1.0.0' (UnauthorizedAccessException: System access is restricted, you are not allowed to use System.IO.FileStream)
at Oxide.Plugins.FSTest.OnServerInitialized ()
```