### PR TITLE
Disable Sandboxing

### DIFF
--- a/src/CSharpExtension.cs
+++ b/src/CSharpExtension.cs
@@ -43,9 +43,6 @@ namespace Oxide.Plugins
         // The .cs plugin loader
         private CSharpPluginLoader loader;
 
-        // Is the sandbox enabled? (always default to true)
-        public static bool SandboxEnabled { get; private set; } = true;
-
         /// <summary>
         /// Initializes a new instance of the CSharpExtension class
         /// </summary>
@@ -75,12 +72,6 @@ namespace Oxide.Plugins
 
             // Register engine frame callback
             Interface.Oxide.OnFrame(OnFrame);
-
-            if (File.Exists(Path.Combine(Interface.Oxide.ExtensionDirectory, "oxide.disable-sandbox")))
-            {
-                Interface.Oxide.LogWarning($"{Path.Combine(Interface.Oxide.ExtensionDirectory, "oxide.disable-sandbox")} found, disabling security sandbox. Potentially dangerous APIs and methods are now allowed inside plugins.");
-                CSharpExtension.SandboxEnabled = false;
-            }
         }
 
         /// <summary>

--- a/src/Compilation.cs
+++ b/src/Compilation.cs
@@ -272,8 +272,7 @@ namespace Oxide.Plugins
                 if (match.Success)
                 {
                     string result = match.Groups[1].Value;
-                    if (!result.StartsWith("Oxide.") && !result.Contains("Newtonsoft.Json")&& !result.Contains("protobuf-net")
-                        || !CSharpExtension.SandboxEnabled && !result.Contains("Harmony"))
+                    if (!result.StartsWith("Oxide.") && !result.Contains("Newtonsoft.Json")&& !result.Contains("protobuf-net") || !result.Contains("Harmony"))
                     {
                         AddReference(plugin, result);
                         Interface.Oxide.LogInfo("Added '// Reference: {0}' in plugin '{1}'", result, plugin.Name);

--- a/src/Compilation.cs
+++ b/src/Compilation.cs
@@ -272,7 +272,7 @@ namespace Oxide.Plugins
                 if (match.Success)
                 {
                     string result = match.Groups[1].Value;
-                    if (!result.StartsWith("Oxide.") && !result.Contains("Newtonsoft.Json")&& !result.Contains("protobuf-net") || !result.Contains("Harmony"))
+                    if (!result.StartsWith("Oxide.") && !result.Contains("Newtonsoft.Json") && !result.Contains("protobuf-net"))
                     {
                         AddReference(plugin, result);
                         Interface.Oxide.LogInfo("Added '// Reference: {0}' in plugin '{1}'", result, plugin.Name);

--- a/src/CompiledAssembly.cs
+++ b/src/CompiledAssembly.cs
@@ -3,17 +3,12 @@ extern alias References;
 using Oxide.Core;
 using Oxide.Core.CSharp;
 using References::Mono.Cecil;
-using References::Mono.Cecil.Cil;
-using References::Mono.Cecil.Rocks;
 using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
 using System.Threading;
-
-using MethodAttributes = References::Mono.Cecil.MethodAttributes;
-using MethodBody = References::Mono.Cecil.Cil.MethodBody;
 
 namespace Oxide.Plugins
 {
@@ -34,16 +29,6 @@ namespace Oxide.Plugins
         private bool isPatching;
         private bool isLoaded;
 
-        private static IEnumerable<string> BlacklistedNamespaces => new[] {
-            "Harmony", "Mono.CSharp", "Mono.Cecil", "Oxide.Core.ServerConsole", "ServerFileSystem", "System.IO", "System.Net", "System.Xml", "System.Reflection.Assembly",
-            "System.Reflection.Emit", "System.Threading", "System.Runtime.InteropServices", "System.Diagnostics", "System.Security", "System.Timers"
-        };
-
-        private static IEnumerable<string> WhitelistedNamespaces => new[] {
-            "System.Diagnostics.Stopwatch", "System.IO.MemoryStream", "System.IO.Stream", "System.IO.BinaryReader", "System.IO.BinaryWriter", "System.IO.StringReader",
-            "System.IO.StringWriter", "System.Net.Dns", "System.Net.Dns.GetHostEntry", "System.Net.IPAddress", "System.Net.IPEndPoint", "System.Net.NetworkInformation",
-            "System.Net.Sockets.SocketFlags", "System.Security.Cryptography", "System.Threading.Interlocked", "System.Threading.Monitor"
-        };
 
         public CompiledAssembly(string name, CompilablePlugin[] plugins, byte[] rawAssembly, float duration)
         {
@@ -106,8 +91,6 @@ namespace Oxide.Plugins
                 return;
             }
 
-            float startedAt = Interface.Oxide.Now;
-
             isPatching = true;
             ThreadPool.QueueUserWorkItem(_ =>
             {
@@ -119,129 +102,8 @@ namespace Oxide.Plugins
                         definition = AssemblyDefinition.ReadAssembly(stream);
                     }
 
-                    ConstructorInfo exceptionConstructor = typeof(UnauthorizedAccessException).GetConstructor(new[] { typeof(string) });
-                    MethodReference securityException = definition.MainModule.Import(exceptionConstructor);
-
-                    Action<TypeDefinition> patchModuleType = null;
-                    patchModuleType = type =>
-                    {
-                        foreach (MethodDefinition method in type.Methods)
-                        {
-                            bool changedMethod = false;
-
-                            if (method.Body == null)
-                            {
-                                if (method.HasPInvokeInfo)
-                                {
-                                    method.Attributes &= ~MethodAttributes.PInvokeImpl;
-                                    MethodBody body = new MethodBody(method);
-                                    body.Instructions.Add(Instruction.Create(OpCodes.Ldstr, "PInvoke access is restricted, you are not allowed to use PInvoke"));
-                                    body.Instructions.Add(Instruction.Create(OpCodes.Newobj, securityException));
-                                    body.Instructions.Add(Instruction.Create(OpCodes.Throw));
-                                    method.Body = body;
-                                }
-                            }
-                            else
-                            {
-                                bool replacedMethod = false;
-                                foreach (VariableDefinition variable in method.Body.Variables)
-                                {
-                                    if (!IsNamespaceBlacklisted(variable.VariableType.FullName))
-                                    {
-                                        continue;
-                                    }
-
-                                    MethodBody body = new MethodBody(method);
-                                    body.Instructions.Add(Instruction.Create(OpCodes.Ldstr, $"System access is restricted, you are not allowed to use {variable.VariableType.FullName}"));
-                                    body.Instructions.Add(Instruction.Create(OpCodes.Newobj, securityException));
-                                    body.Instructions.Add(Instruction.Create(OpCodes.Throw));
-                                    method.Body = body;
-                                    replacedMethod = true;
-                                    break;
-                                }
-                                if (replacedMethod)
-                                {
-                                    continue;
-                                }
-
-                                References::Mono.Collections.Generic.Collection<Instruction> instructions = method.Body.Instructions;
-                                ILProcessor ilProcessor = method.Body.GetILProcessor();
-                                Instruction first = instructions.First();
-
-                                int i = 0;
-                                while (i < instructions.Count && !changedMethod)
-                                {
-                                    Instruction instruction = instructions[i];
-                                    if (instruction.OpCode == OpCodes.Ldtoken)
-                                    {
-                                        IMetadataTokenProvider operand = instruction.Operand as IMetadataTokenProvider;
-                                        string token = operand?.ToString();
-                                        if (IsNamespaceBlacklisted(token))
-                                        {
-                                            ilProcessor.InsertBefore(first, Instruction.Create(OpCodes.Ldstr, $"System access is restricted, you are not allowed to use {token}"));
-                                            ilProcessor.InsertBefore(first, Instruction.Create(OpCodes.Newobj, securityException));
-                                            ilProcessor.InsertBefore(first, Instruction.Create(OpCodes.Throw));
-                                            changedMethod = true;
-                                        }
-                                    }
-                                    else if (instruction.OpCode == OpCodes.Call || instruction.OpCode == OpCodes.Calli || instruction.OpCode == OpCodes.Callvirt || instruction.OpCode == OpCodes.Ldftn || instruction.OpCode == OpCodes.Newobj)
-                                    {
-                                        MethodReference methodCall = instruction.Operand as MethodReference;
-                                        string fullNamespace = methodCall?.DeclaringType.FullName;
-
-                                        if ((fullNamespace == "System.Type" && methodCall.Name == "GetType") || IsNamespaceBlacklisted(fullNamespace))
-                                        {
-                                            ilProcessor.InsertBefore(first, Instruction.Create(OpCodes.Ldstr, $"System access is restricted, you are not allowed to use {fullNamespace}"));
-                                            ilProcessor.InsertBefore(first, Instruction.Create(OpCodes.Newobj, securityException));
-                                            ilProcessor.InsertBefore(first, Instruction.Create(OpCodes.Throw));
-                                            changedMethod = true;
-                                        }
-                                    }
-                                    else if (instruction.OpCode == OpCodes.Ldfld)
-                                    {
-                                        FieldReference fieldType = instruction.Operand as FieldReference;
-                                        string fullNamespace = fieldType?.FieldType.FullName;
-                                        if (IsNamespaceBlacklisted(fullNamespace))
-                                        {
-                                            ilProcessor.InsertBefore(first, Instruction.Create(OpCodes.Ldstr, $"System access is restricted, you are not allowed to use {fullNamespace}"));
-                                            ilProcessor.InsertBefore(first, Instruction.Create(OpCodes.Newobj, securityException));
-                                            ilProcessor.InsertBefore(first, Instruction.Create(OpCodes.Throw));
-                                            changedMethod = true;
-                                        }
-                                    }
-                                    i++;
-                                }
-                            }
-
-                            if (changedMethod)
-                            {
-                                method.Body?.OptimizeMacros();
-                                /*//Interface.Oxide.LogDebug("Updating {0} instruction offsets: {1}", instructions.Count, method.FullName);
-                                int curoffset = 0;
-                                for (var i = 0; i < instructions.Count; i++)
-                                {
-                                    var instruction = instructions[i];
-                                    instruction.Previous = (i == 0) ? null : instructions[i - 1];
-                                    instruction.Next = (i == instructions.Count - 1) ? null : instructions[i + 1];
-                                    instruction.Offset = curoffset;
-                                    curoffset += instruction.GetSize();
-                                    //Interface.Oxide.LogDebug("    {0}", instruction.ToString());
-                                }*/
-                            }
-                        }
-                        foreach (TypeDefinition nestedType in type.NestedTypes)
-                        {
-                            patchModuleType(nestedType);
-                        }
-                    };
-
                     foreach (TypeDefinition type in definition.MainModule.Types)
                     {
-                        if (CSharpExtension.SandboxEnabled)
-                        {
-                            patchModuleType(type);
-                        }
-
                         if (IsCompilerGenerated(type))
                         {
                             continue;
@@ -287,24 +149,24 @@ namespace Oxide.Plugins
                     }
 
                     // TODO: Why is there no error on boot using this?
-                    foreach (TypeDefinition type in definition.MainModule.Types)
-                    {
-                        if (type.Namespace != "Oxide.Plugins" || !PluginNames.Contains(type.Name))
-                        {
-                            continue;
-                        }
-
-                        foreach (MethodDefinition m in type.Methods.Where(m => !m.IsStatic && !m.HasGenericParameters && !m.ReturnType.IsGenericParameter && !m.IsSetter && !m.IsGetter))
-                        {
-                            foreach (ParameterDefinition parameter in m.Parameters)
-                            {
-                                foreach (CustomAttribute attribute in parameter.CustomAttributes)
-                                {
-                                    //Interface.Oxide.LogInfo($"{m.FullName} - {parameter.Name} - {attribute.Constructor.FullName}");
-                                }
-                            }
-                        }
-                    }
+                    // foreach (TypeDefinition type in definition.MainModule.Types)
+                    // {
+                    //     if (type.Namespace != "Oxide.Plugins" || !PluginNames.Contains(type.Name))
+                    //     {
+                    //         continue;
+                    //     }
+                    //
+                    //     foreach (MethodDefinition m in type.Methods.Where(m => !m.IsStatic && !m.HasGenericParameters && !m.ReturnType.IsGenericParameter && !m.IsSetter && !m.IsGetter))
+                    //     {
+                    //         foreach (ParameterDefinition parameter in m.Parameters)
+                    //         {
+                    //             foreach (CustomAttribute attribute in parameter.CustomAttributes)
+                    //             {
+                    //                 //Interface.Oxide.LogInfo($"{m.FullName} - {parameter.Name} - {attribute.Constructor.FullName}");
+                    //             }
+                    //         }
+                    //     }
+                    // }
 
                     using (MemoryStream stream = new MemoryStream())
                     {
@@ -335,24 +197,5 @@ namespace Oxide.Plugins
         public bool IsOutdated() => CompilablePlugins.Any(pl => pl.GetLastModificationTime() != CompiledAt);
 
         private bool IsCompilerGenerated(TypeDefinition type) => type.CustomAttributes.Any(attr => attr.Constructor.DeclaringType.ToString().Contains("CompilerGeneratedAttribute"));
-
-        private static bool IsNamespaceBlacklisted(string fullNamespace)
-        {
-            foreach (string namespaceName in BlacklistedNamespaces)
-            {
-                if (!fullNamespace.StartsWith(namespaceName))
-                {
-                    continue;
-                }
-
-                if (WhitelistedNamespaces.Any(fullNamespace.StartsWith))
-                {
-                    continue;
-                }
-
-                return true;
-            }
-            return false;
-        }
     }
 }


### PR DESCRIPTION
Oxide's sandbox is a major pain point for many developers, which might be fine if it was actually secure, but it's not a real sandbox. It's just a namespace blacklist. This is security through obscurity & annoyance, and is inherently flawed for many reasons:

- It's extremely easy to bypass in many ways
- It fails to actually blacklist all possible valid MSIL
- It cannot possibly cover every exploitable surface in every game you support, as you are not vetting the contents of every game DLL a plugin can reference
- It does not care about the potential contents of code called in non-blacklisted namespaces, which can proxy requests to blacklisted functions
- Any form of arbitrary disk writing provides an easy attack vector to turn it off

The simple fact that Oxide can load plugins and run them at the user level is inherently Remote Code Execution. It's not sandboxed like web browsers or Docker, it's .NET code running bare metal on the system. The sandbox currently is no better than obfuscation---it can be bypassed by anyone savvy enough to understand it.

### Bypassing The Sandbox: Example

Currently, reflection is allowed to get and set private fields. Many plugins on uMod.org depend on this to function. This makes it extremely trivial to bypass the sandbox simply by setting `CSharpExtension.SandboxEnabled` to false.

```csharp
var field = typeof(CSharpExtension).GetField("<SandboxEnabled>k__BackingField", BindingFlags.Static | BindingFlags.NonPublic);
field.SetValue(null, false);
```

This is the most obvious flaw, but I have found two other bypasses with a few hours of tinkering. Even if all patched, there will always be another namespace you need to blacklist that only needs a few more hours of debugging to find.

### False Sense of Security

The naming of the "sandbox" implies that code run through Oxide plugins will always be secure, which raises problems when trying to get end users to disable the sandbox to use Harmony patches. It gives a false sense of security; users *should be scared at all times* of running unvetted code on their system. 

Even if the sandbox actually worked, it wouldn't be very useful. With sites like uMod, CodeFling, and LoneDesign all having manual review of plugins. Users primarily download plugins from these places, and can trust them to be safe. Unless you download plugins from random sketchy sites (the equivalent of running an `.exe` on your computer), you are safe. Even still, I have not heard of server owners getting hacked, despite how easy it is to bypass the sandbox. 
