### PR TITLE
LogToFile: Timestamps in logs

### DIFF
--- a/src/CSharpPlugin.cs
+++ b/src/CSharpPlugin.cs
@@ -469,7 +469,7 @@ namespace Oxide.Plugins
             filename = $"{plugin.Name.ToLower()}_{filename.ToLower()}{(timeStamp ? $"-{DateTime.Now:yyyy-MM-dd}" : "")}.txt";
             using (StreamWriter writer = new StreamWriter(Path.Combine(path, Utility.CleanPath(filename)), true))
             {
-                writer.WriteLine(text);
+                writer.WriteLine(timeStamp ? $"[{DateTime.Now:yyyy-MM-dd HH:mm:ss}] " + text : text);
             }
         }
 


### PR DESCRIPTION
Oddly enough there wasn't support for timestamps inside the actual logfile which would feel much more intuitive with the timestamp parameter.