### PR TITLE
Allow multiple command attributes on methods

### DIFF
--- a/src/CompilerStream/CompilerMessage.cs
+++ b/src/CompilerStream/CompilerMessage.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Oxide.CSharp.CompilerStream
+{
+    public sealed class CompilerMessage
+    {
+        public MessageType Type { get; set; }
+
+        public byte[] Data { get; set; }
+    }
+}

--- a/src/CompilerStream/MessageType.cs
+++ b/src/CompilerStream/MessageType.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace Oxide.CSharp.CompilerStream
+{
+    [Flags]
+    public enum MessageType : byte
+    {
+        Unknown = 0x00,
+
+        Acknowledge = 0x01,
+
+        Heartbeat = 0x02,
+
+        VersionInfo = 0x04,
+
+        Ready = 0x08,
+
+        Command = 0x16,
+
+        Data = 0x32,
+
+        Shutdown = 0x64
+    }
+}

--- a/src/Oxide.CSharp.csproj
+++ b/src/Oxide.CSharp.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project>
   <Import Project="Sdk.props" Sdk="Microsoft.NET.Sdk" />
   <Import Project="..\netfx.props" />
@@ -17,8 +17,8 @@
     <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Oxide.Common" Version="2.0.30-messaging" />
     <PackageReference Include="Oxide.Core" Version="2.0.*" />
-    <PackageReference Include="Oxide.Common" Version="2.0.*" />
     <PackageReference Include="Oxide.References" Version="2.0.*">
       <PrivateAssets>contentfiles;analyzers;build</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
**Objective**
Allow using multiple command attributes on methods. 

**Issue**
```csharp
    [Command("cmd1")]
    private void Shortcut(IPlayer iPlayer, string cmd, string[] args)
    {
        TrueCommand(iPlayer, cmd, args);
    }

    [Command("cmd2")]
    private void TrueCommand(IPlayer iPlayer, string cmd, string[] args)
    {
        ...
    }
```

**Solution**
```
    [Command("cmd1")]
    [Command("cmd2")]
    private void TrueCommand(IPlayer iPlayer, string cmd, string[] args)
    {
        ...
    }
```